### PR TITLE
Settings, database saving, and reactivity

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -30,6 +30,7 @@
     "no-spaced-func": "off",
     "func-call-spacing": "off",
     "@typescript-eslint/func-call-spacing": ["error"],
-    "@typescript-eslint/no-unused-vars": [ "warn", { "argsIgnorePattern": "^_" }]
+    "@typescript-eslint/no-unused-vars": [ "warn", { "argsIgnorePattern": "^_" }],
+    "no-param-reassign": [ "error", { "props": false } ]
   }
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -4,9 +4,10 @@ import { invoke } from '@tauri-apps/api/tauri';
 import WindowTitlebar from './components/WindowTitlebar.vue';
 import SettingsMenu from './components/SettingsMenu.vue';
 import { Theme } from './model/enum';
+import { Database } from './database';
 
+const db = await Database.loadRef();
 
-const theme = ref(Theme.Dark);
 const show_settings = ref(false);
 
 let is_first_resolve = true;
@@ -25,11 +26,11 @@ async function first_resolve() {
     <div
       id="root"
       class="is-flex is-flex-direction-column"
-      :class="theme"
+      :class="db.theme"
     >
       <div class="is-flex-shrink-0">
         <WindowTitlebar
-          @toggle-theme="theme = (theme === Theme.Dark ? Theme.Light : Theme.Dark)"
+          @toggle-theme="db.theme = (db.theme === Theme.Dark ? Theme.Light : Theme.Dark)"
           @toggle-settings="show_settings = !show_settings"
         />
       </div>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,13 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue';
 import { invoke } from '@tauri-apps/api/tauri';
-import WindowTitlebar from './components/WindowTitlebar.vue';
-import SettingsMenu from './components/SettingsMenu.vue';
-import { Database } from './database';
-
-const db = await Database.loadRef();
-
-const show_settings = ref(false);
 
 let is_first_resolve = true;
 
@@ -22,46 +14,10 @@ async function first_resolve() {
 
 <template>
   <Suspense @resolve="first_resolve">
-    <div
-      id="root"
-      class="is-flex is-flex-direction-column"
-      :class="db.theme"
-    >
-      <div class="is-flex-shrink-0">
-        <WindowTitlebar
-          @toggle-settings="show_settings = !show_settings"
-        />
-      </div>
-      <div class="is-flex-grow-1 is-relative">
-        <RouterView v-slot="{ Component, route }">
-          <Transition :name="(route.meta?.transition as string | undefined) ?? ''">
-            <div
-              :key="route.name ?? 'Home'"
-              class="transition-wrapper"
-            >
-              <component :is="Component" />
-            </div>
-          </Transition>
-        </RouterView>
-        <Transition name="slide">
-          <SettingsMenu
-            v-if="show_settings"
-            class="settings"
-          />
-        </Transition>
-      </div>
-    </div>
+    <RouterView />
   </Suspense>
 </template>
 
 <style lang="scss">
 @import "@/assets/styles/styles";
-
-.settings {
-  height: 100%;
-  left: 0;
-  position: absolute;
-  top: 0;
-  width: 100%;
-}
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -3,11 +3,8 @@ import { ref } from 'vue';
 import { invoke } from '@tauri-apps/api/tauri';
 import WindowTitlebar from './components/WindowTitlebar.vue';
 import SettingsMenu from './components/SettingsMenu.vue';
+import { Theme } from './model/enum';
 
-enum Theme {
-  Light = 'light',
-  Dark = 'dark',
-}
 
 const theme = ref(Theme.Dark);
 const show_settings = ref(false);

--- a/src/App.vue
+++ b/src/App.vue
@@ -3,7 +3,6 @@ import { ref } from 'vue';
 import { invoke } from '@tauri-apps/api/tauri';
 import WindowTitlebar from './components/WindowTitlebar.vue';
 import SettingsMenu from './components/SettingsMenu.vue';
-import { Theme } from './model/enum';
 import { Database } from './database';
 
 const db = await Database.loadRef();
@@ -30,7 +29,6 @@ async function first_resolve() {
     >
       <div class="is-flex-shrink-0">
         <WindowTitlebar
-          @toggle-theme="db.theme = (db.theme === Theme.Dark ? Theme.Light : Theme.Dark)"
           @toggle-settings="show_settings = !show_settings"
         />
       </div>

--- a/src/components/WindowTitlebar.vue
+++ b/src/components/WindowTitlebar.vue
@@ -2,7 +2,7 @@
 import { appWindow } from '@tauri-apps/api/window';
 import { onUnmounted, ref } from 'vue';
 
-const emit = defineEmits(['toggleTheme', 'toggleSettings']);
+const emit = defineEmits(['toggleSettings']);
 const is_maximized = ref(await appWindow.isMaximized());
 const is_focused = ref(true);
 
@@ -36,17 +36,6 @@ onUnmounted(() => {
         <FontAwesomeIcon
           icon="fa-solid fa-bars"
           alt="settings"
-        />
-      </div>
-      <div
-        class="square-icon-button"
-        tabindex="0"
-        @click="emit('toggleTheme')"
-        @keypress.enter="emit('toggleTheme')"
-      >
-        <FontAwesomeIcon
-          icon="fa-solid fa-lightbulb"
-          alt="theme"
         />
       </div>
     </div>

--- a/src/components/settings/SettingField.vue
+++ b/src/components/settings/SettingField.vue
@@ -2,6 +2,7 @@
 import { Ref, ref, watch } from 'vue';
 import { Setting } from '../../model/Setting';
 import PopupModal from '../PopupModal.vue';
+import ItemList from '../ItemList.vue';
 
 const props = defineProps<{
   setting: Setting<any, any>
@@ -45,8 +46,54 @@ function edit_bool(newVal: boolean) {
 </script>
 
 <template>
+  <div v-if="setting.possible_values !== null">
+    <div class="level mb-0">
+      <div class="overflow-x-hidden">
+        <div class="label mb-0">
+          {{ setting.name }}
+        </div>
+      </div>
+      <div class="dropdown is-active">
+        <Popper
+          offset-distance="6"
+          offset-skid="-150"
+          placement="bottom"
+        >
+          <div class="dropdown-trigger">
+            <button
+              class="button"
+              aria-haspopup="true"
+              aria-controls="dropdown-menu"
+            >
+              <span>{{ setting.value }}</span>
+              <span class="icon">
+                <FontAwesomeIcon icon="fa-solid fa-chevron-down" />
+              </span>
+            </button>
+          </div>
+          <template #content="{ close }">
+            <div
+              id="dropdown-menu"
+              class="dropdown-menu"
+              role="menu"
+            >
+              <div class="dropdown-content">
+                <ItemList
+                  layout="dropdown-select"
+                  :list="setting.possible_values"
+                  :default_item="setting.value"
+                  :get_key="(val: any) => val"
+                  @changed="(val: any) => { emit('changed', val); close(); }"
+                />
+              </div>
+            </div>
+          </template>
+        </Popper>
+      </div>
+    </div>
+  </div>
   <div
-    v-if="typeof setting.value === 'string'"
+    v-else-if="typeof setting.value === 'string'"
     class="field"
   >
     <div class="level mb-0">

--- a/src/components/settings/SettingField.vue
+++ b/src/components/settings/SettingField.vue
@@ -4,7 +4,7 @@ import { Setting } from '../../model/Setting';
 import PopupModal from '../PopupModal.vue';
 
 const props = defineProps<{
-  setting: Setting<any>
+  setting: Setting<any, any>
 }>();
 
 const emit = defineEmits(['changed']);
@@ -17,7 +17,7 @@ const show_edit_string_modal = ref(false);
 watch(
   () => string_val.value,
   (val) => {
-    error_message.value = props.setting.valid(val.trim());
+    error_message.value = props.setting.is_valid(val.trim());
   },
 );
 
@@ -34,7 +34,7 @@ function close_edit_string_modal(save: boolean) {
 }
 
 function edit_bool(newVal: boolean) {
-  const valid = props.setting.valid(newVal);
+  const valid = props.setting.is_valid(newVal);
   error_message.value = valid;
   if (valid === null) {
     emit('changed', newVal);

--- a/src/components/settings/SettingsProfile.vue
+++ b/src/components/settings/SettingsProfile.vue
@@ -1,27 +1,17 @@
 <script setup lang="ts">
-import { Setting } from '../../model/Setting';
+import { DatabaseSetting, Setting, theme_setting, username_setting } from '../../model/Setting';
 import UserAvatar from '../UserAvatar.vue';
 import SettingField from './SettingField.vue';
 
-const profile_settings: Setting<any>[] = [
-  {
-    key: 'username',
-    name: 'Username',
-    value: 'MyName',
-    valid: (val: string) => {
-      if (val.length < 3 || val.length > 50) {
-        return 'Username must be between 3 and 50 characters.';
-      }
-      return null;
-    },
-  } as Setting<string>,
-  {
-    key: 'dark-theme',
-    name: 'Dark Theme',
-    value: true,
-    valid: (_) => null,
-  } as Setting<boolean>,
+const profile_settings: DatabaseSetting<any>[] = [
+  username_setting,
+  theme_setting,
 ];
+
+async function changed<T>(setting: Setting<any, T>, newVal: T) {
+  setting.value = newVal;
+  await setting.save();
+}
 </script>
 
 <template>
@@ -38,7 +28,7 @@ const profile_settings: Setting<any>[] = [
       v-for="profile_setting in profile_settings"
       :key="profile_setting.key"
       :setting="profile_setting"
-      @changed="(newVal) => profile_setting.value = newVal"
+      @changed="(newVal) => changed(profile_setting, newVal)"
     />
   </div>
 </template>

--- a/src/components/settings/SettingsProfile.vue
+++ b/src/components/settings/SettingsProfile.vue
@@ -1,12 +1,13 @@
 <script setup lang="ts">
+import { Ref, ref } from 'vue';
 import { DatabaseSetting, Setting, theme_setting, username_setting } from '../../model/Setting';
 import UserAvatar from '../UserAvatar.vue';
 import SettingField from './SettingField.vue';
 
-const profile_settings: DatabaseSetting<any>[] = [
+const profile_settings: Ref<DatabaseSetting<any>[]> = ref([
   username_setting,
   theme_setting,
-];
+]);
 
 async function changed<T>(setting: Setting<any, T>, newVal: T) {
   setting.value = newVal;

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -160,7 +160,6 @@ export abstract class Database {
 export class Database_v0 extends Database {
   @Expose() readonly db_version = '0.0.0';
 
-  @Expose() example = 'example data';
   @Expose() username = 'example data';
   @Expose() theme: Theme = Theme.Dark;
 

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -3,6 +3,13 @@ import { BaseDirectory, createDir, readTextFile, writeTextFile } from '@tauri-ap
 import { plainToInstance, instanceToPlain, Expose } from 'class-transformer';
 import 'reflect-metadata';
 import { gt as semVerGt, neq as semVerNeq, satisfies as semVerSatisfies, valid as semVerValid, clean as semVerClean } from 'semver';
+import { Theme } from '../model/enum';
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+type Fields<T> = Pick<T, { [K in keyof T]: T[K] extends Function ? never : K }[keyof T]>;
+type KeysWithValsOfType<T, V> = keyof { [ P in keyof T as T[P] extends V ? P : never ] : P };
+export type DatabaseFields<T> = Omit<Fields<T>, 'db_version'>
+export type DatabaseFieldsOfType<T, U> = KeysWithValsOfType<DatabaseFields<T>, U>;
 
 /**
  * The base database class.
@@ -154,6 +161,8 @@ export class Database_v0 extends Database {
   @Expose() readonly db_version = '0.0.0';
 
   @Expose() example = 'example data';
+  @Expose() username = 'example data';
+  @Expose() theme: Theme = Theme.Dark;
 
   serialize(): string {
     return JSON.stringify(instanceToPlain(this, { strategy: 'excludeAll' }), undefined, 2);

--- a/src/model/Setting.ts
+++ b/src/model/Setting.ts
@@ -1,22 +1,25 @@
 /* eslint-disable max-classes-per-file */
-import { Database, DatabaseFields, DatabaseFieldsOfType, Database_v0 } from '../database';
+import { Database, DatabaseFields, DatabaseFieldsOfType, DatabaseLatest } from '../database';
 import { Theme } from './enum';
 
 export abstract class Setting<K extends string, T> {
   readonly key: K;
   name: string;
   value: T;
+  possible_values: T[] | null;
   validator: (val: T) => string | null;
 
   constructor(
     key: K,
     name: string,
     value: T,
+    possible_values: T[] | null,
     validator: (val: T) => string | null,
   ) {
     this.key = key;
     this.name = name;
     this.value = value;
+    this.possible_values = possible_values;
     this.validator = validator;
   }
 
@@ -34,10 +37,11 @@ export class BasicSetting<T> extends Setting<string, T> {
     key: string,
     name: string,
     value: T,
+    possible_values: T[] | null,
     validator: (val: T) => string | null,
     saver: (key: string, val: T) => Promise<void>,
   ) {
-    super(key, name, value, validator);
+    super(key, name, value, possible_values, validator);
     this.saver = saver;
   }
 
@@ -61,6 +65,7 @@ const username_setting = new DatabaseSetting<string>(
   'username',
   'Username',
   db.value.username,
+  null,
   (val: string) => {
     if (val.length < 3 || val.length > 50) {
       return 'Username must be between 3 and 50 characters.';
@@ -73,6 +78,7 @@ const theme_setting = new DatabaseSetting<Theme>(
   'theme',
   'Theme',
   db.value.theme,
+  Object.values(Theme),
   (_) => null,
 );
 

--- a/src/model/Setting.ts
+++ b/src/model/Setting.ts
@@ -1,6 +1,57 @@
-export interface Setting<T> {
-  key: string,
-  name: string,
-  value: T,
-  valid: (val: T) => string | null
+/* eslint-disable max-classes-per-file */
+import { Database, DatabaseFields, DatabaseFieldsOfType, Database_v0 } from '../database';
+import { Theme } from './enum';
+
+export abstract class Setting<K extends string, T> {
+  readonly key: K;
+  name: string;
+  value: T;
+  validator: (val: T) => string | null;
+
+  constructor(
+    key: K,
+    name: string,
+    value: T,
+    validator: (val: T) => string | null,
+  ) {
+    this.key = key;
+    this.name = name;
+    this.value = value;
+    this.validator = validator;
+  }
+
+  is_valid(value: T): string | null {
+    return this.validator(value);
+  }
+
+  abstract save(): Promise<void>;
 }
+
+export class BasicSetting<T> extends Setting<string, T> {
+  saver: (key: string, val: T) => Promise<void>;
+
+  constructor(
+    key: string,
+    name: string,
+    value: T,
+    validator: (val: T) => string | null,
+    saver: (key: string, val: T) => Promise<void>,
+  ) {
+    super(key, name, value, validator);
+    this.saver = saver;
+  }
+
+  async save() {
+    this.saver(this.key, this.value);
+  }
+}
+
+export class DatabaseSetting<T extends DatabaseFields<Database_v0>[keyof DatabaseFields<Database_v0>]>
+  extends Setting<DatabaseFieldsOfType<Database_v0, T>, T> {
+  async save() {
+    const db: Database_v0 = await Database.load();
+    db[this.key] = this.value as any;
+    await db.save();
+  }
+}
+

--- a/src/model/Setting.ts
+++ b/src/model/Setting.ts
@@ -55,3 +55,25 @@ export class DatabaseSetting<T extends DatabaseFields<Database_v0>[keyof Databas
   }
 }
 
+const db = await Database.load();
+
+const username_setting = new DatabaseSetting<string>(
+  'username',
+  'Username',
+  db.username,
+  (val: string) => {
+    if (val.length < 3 || val.length > 50) {
+      return 'Username must be between 3 and 50 characters.';
+    }
+    return null;
+  },
+);
+
+const theme_setting = new DatabaseSetting<Theme>(
+  'theme',
+  'Theme',
+  db.theme,
+  (_) => null,
+);
+
+export { username_setting, theme_setting };

--- a/src/model/Setting.ts
+++ b/src/model/Setting.ts
@@ -46,10 +46,10 @@ export class BasicSetting<T> extends Setting<string, T> {
   }
 }
 
-export class DatabaseSetting<T extends DatabaseFields<Database_v0>[keyof DatabaseFields<Database_v0>]>
-  extends Setting<DatabaseFieldsOfType<Database_v0, T>, T> {
+export class DatabaseSetting<T extends DatabaseFields<DatabaseLatest>[keyof DatabaseFields<DatabaseLatest>]>
+  extends Setting<DatabaseFieldsOfType<DatabaseLatest, T>, T> {
   async save() {
-    const db: Database_v0 = await Database.load();
+    const db = (await Database.load()).value;
     db[this.key] = this.value as any;
     await db.save();
   }
@@ -60,7 +60,7 @@ const db = await Database.load();
 const username_setting = new DatabaseSetting<string>(
   'username',
   'Username',
-  db.username,
+  db.value.username,
   (val: string) => {
     if (val.length < 3 || val.length > 50) {
       return 'Username must be between 3 and 50 characters.';
@@ -72,7 +72,7 @@ const username_setting = new DatabaseSetting<string>(
 const theme_setting = new DatabaseSetting<Theme>(
   'theme',
   'Theme',
-  db.theme,
+  db.value.theme,
   (_) => null,
 );
 

--- a/src/model/enum.ts
+++ b/src/model/enum.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/prefer-default-export
 export enum Theme {
-  Light = 'light',
-  Dark = 'dark',
+  Light = 'Light',
+  Dark = 'Dark',
 }

--- a/src/model/enum.ts
+++ b/src/model/enum.ts
@@ -1,0 +1,5 @@
+// eslint-disable-next-line import/prefer-default-export
+export enum Theme {
+  Light = 'light',
+  Dark = 'dark',
+}

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -3,8 +3,15 @@ import { createRouter, createWebHistory, RouteRecordRaw } from 'vue-router';
 const routes: Array<RouteRecordRaw> = [
   {
     path: '/',
-    name: 'Home',
-    component: () => import('../views/HomeView.vue'),
+    name: 'Root',
+    component: () => import('../views/RootView.vue'),
+    children: [
+      {
+        path: '',
+        name: 'Home',
+        component: () => import('../views/HomeView.vue'),
+      },
+    ],
   },
 ];
 

--- a/src/views/RootView.vue
+++ b/src/views/RootView.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import WindowTitlebar from '../components/WindowTitlebar.vue';
+import SettingsMenu from '../components/SettingsMenu.vue';
+import { Database } from '../database';
+
+const db = await Database.load();
+
+const show_settings = ref(false);
+</script>
+
+<template>
+  <div
+    id="root"
+    class="is-flex is-flex-direction-column"
+    :class="db.theme.toLowerCase()"
+  >
+    <div class="is-flex-shrink-0">
+      <WindowTitlebar
+        @toggle-settings="show_settings = !show_settings"
+      />
+    </div>
+    <div class="is-flex-grow-1 is-relative">
+      <RouterView v-slot="{ Component, route }">
+        <Transition :name="(route.meta?.transition as string | undefined) ?? ''">
+          <div
+            :key="route.name ?? 'Home'"
+            class="transition-wrapper"
+          >
+            <component :is="Component" />
+          </div>
+        </Transition>
+      </RouterView>
+      <Transition name="slide">
+        <SettingsMenu
+          v-if="show_settings"
+          class="settings"
+        />
+      </Transition>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.settings {
+  height: 100%;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+}
+</style>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -34,7 +34,7 @@ export default defineConfig({
         entryFileNames: 'assets/js/[name].[hash].js',
       },
     },
-    target: ['es2021', 'chrome100', 'safari15'],
+    target: ['chrome100', 'safari15'],
   },
   css: {
     preprocessorOptions: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -34,6 +34,7 @@ export default defineConfig({
         entryFileNames: 'assets/js/[name].[hash].js',
       },
     },
+    target: ['es2021', 'chrome100', 'safari15'],
   },
   css: {
     preprocessorOptions: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -34,7 +34,7 @@ export default defineConfig({
         entryFileNames: 'assets/js/[name].[hash].js',
       },
     },
-    target: ['chrome100', 'safari15'],
+    target: ['edge89', 'safari15'],
   },
   css: {
     preprocessorOptions: {


### PR DESCRIPTION
- Introduces `Setting`, `BasicSetting`, and `DatabaseSetting` classes
- `DatabaseSetting` automatically saves the new value to the database on `save()`
- `Database.singleton` is a Vue Ref by default for reactivity
- Titlebar theme button is removed as theme setting is now available
- `SettingField` component now supports settings with a set of predefined possible values, displaying them in a dropdown
- Restricts target browser versions to `edge89` and `safari15`