### PR TITLE
Rust release build optimisations

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -11,6 +11,12 @@ rust-version = "1.57"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[profile.release]
+panic = "abort"
+codegen-units = 1
+lto = true
+strip = true
+
 [build-dependencies]
 tauri-build = { version = "1.0", features = [] }
 


### PR DESCRIPTION
Reduces bundle size (by 39% on mac for example) and (theoretically) improves performance, at the cost of slightly longer build times (10-15%).